### PR TITLE
feat: Add flash check pipeline job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,5 @@ COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 
 COPY casc_configs/common "casc_configs/${CASC_ENV}" "${CASC_JENKINS_CONFIG}/"
+COPY job_scripts /var/job_scripts
 

--- a/casc_configs/common/flash_check.yaml
+++ b/casc_configs/common/flash_check.yaml
@@ -1,0 +1,13 @@
+jobs:
+  - script: >
+      pipelineJob('flash_check') {
+        triggers {
+          cron("H 23 * * *")
+        }
+        definition {
+          cps {
+            sandbox()
+            script("""${readFile:/var/job_scripts/flash_check/job.groovy}""")
+          }
+        }
+      }

--- a/job_scripts/flash_check/job.groovy
+++ b/job_scripts/flash_check/job.groovy
@@ -1,0 +1,93 @@
+// Note: When creating this with jobdsl and casc the dollar sign variables
+// Require some special love, a backslash dollar sign and a backslash newline
+// is needed it appears...
+
+nodes = nodesByLabel('HIL')
+nodeBoards = []
+
+pipeline {
+    agent { label 'master' }
+    options {
+        // If the whole process takes more than x hours then exit
+        // This must be longer since multiple jobs can be started but waiting on nodes to complete
+        timeout(time: 3, unit: 'HOURS')
+        // Failing fast allows the nodes to be interrupted as some steps can take a while
+        parallelsAlwaysFailFast()
+    }
+  stages {
+         stage('setup build server and build') {
+            steps {
+                stepGetBoards()
+            }
+        }
+        stage('node test') {
+            steps {
+                runParallel items: nodeBoards.collect { "\$\
+{it}" }
+            }
+        }
+    }
+
+}
+
+def runParallel(args) {
+    parallel args.items.collectEntries { name -> [ "\$\
+{name}": {
+
+        node (name) {
+            stage("\$\
+{name}") {
+                /* We want to timeout a node if it doesn't respond
+                 * The timeout should only start once it is acquired
+                 */
+                timeout(time: 60, unit: 'MINUTES') {
+                    script {
+                        stepRunNodeTests()
+                    }
+                }
+            }
+        }
+    }]}
+}
+
+
+def stepRunNodeTests()
+{
+    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+
+        stage("Flash and test") {
+            def timeout_stop_exc = null
+            catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE',
+                    catchInterruptions: false) {
+                stepFlashAndTest()
+            }
+        }
+    }
+}
+
+def stepFlashAndTest()
+{
+    exit_code = sh script: "make flash-only test -C /opt/RIOT/tests/shell", returnStatus:true
+    if (exit_code != 0) {
+        sh script: "sudo reboot"
+    }
+}
+
+def stepGetBoards() {
+    nodeBoards = getBoardsFromNodesEnv()
+    sh script: "echo collected boards: ${nodeBoards.join(",")}",
+            label: "print boards"
+}
+
+def getBoardsFromNodesEnv() {
+    script {
+        boards = []
+        for (int i=0; i < nodes.size(); ++i) {
+            node (nodes[i]) {
+                boards.push(env.BOARD)
+            }
+        }
+        boards.unique()
+        return boards
+    }
+}


### PR DESCRIPTION
This PR sets up a way to add jobs to the casc via jobdsl.
It allows groovy scripts to be imported.
The first implementation is a flash check that flashes all hil nodes,
and if there is a failure then it reboots the node.
Note, it requires all pis to have RIOT with the binary for that board built in `opt/RIOT`

Another issue is that the ${} cannot be included in the .groovy script that easy since things get resolved by yml and jobdsl.
A workaround to this is adding
```
\$\
{my_variable}
```
instead of
```
${my_variable}
```