### PR TITLE
vars/common: Allow console log links

### DIFF
--- a/casc_configs/common/script_security.yaml
+++ b/casc_configs/common/script_security.yaml
@@ -13,5 +13,7 @@ security:
     - method jenkins.model.Jenkins getNode java.lang.String
     - new java.util.AbstractMap$SimpleImmutableEntry java.lang.Object java.lang.Object
     - staticMethod jenkins.model.Jenkins getInstance
+    - staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods asSynchronized java.util.List
+    - staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods asSynchronized java.util.Map
   globalJobDslSecurityConfiguration:
     useScriptSecurity: false

--- a/dsl_scripts/riot_tests.groovy
+++ b/dsl_scripts/riot_tests.groovy
@@ -2,7 +2,7 @@ pipelineJob('riot_tests') {
     description("Runs riot (on-target) tests on boards based on parameters.")
     logRotator {
         numToKeep(512)
-        artifactNumToKeep(32)
+        artifactNumToKeep(512)
     }
     parameters {
         stringParam('HIL_BOARDS', 'all', 'Space separated list of boards to run tests on, if all then all boards connected will run.')

--- a/job_scripts/nightly.groovy
+++ b/job_scripts/nightly.groovy
@@ -9,8 +9,8 @@ import jenkins.model.*
 /* Global variables are decalred without `def` as they must be used in both
  * declaritive and scripted mode */
 collectBuilders = [:]
-boardTestQueue = []
-totalResults = [:]
+boardTestQueue = [].asSynchronized()
+totalResults = [:].asSynchronized()
 nodeBoards = []
 
 /* pipeline ================================================================= */

--- a/job_scripts/riot_tests.groovy
+++ b/job_scripts/riot_tests.groovy
@@ -9,8 +9,8 @@ import jenkins.model.*
 /* Global variables are decalred without `def` as they must be used in both
  * declaritive and scripted mode */
 collectBuilders = [:]
-boardTestQueue = []
-totalResults = [:]
+boardTestQueue = [].asSynchronized()
+totalResults = [:].asSynchronized()
 nodeBoards = []
 
 /* pipeline ================================================================= */

--- a/job_scripts/robot_tests.groovy
+++ b/job_scripts/robot_tests.groovy
@@ -10,8 +10,8 @@ import jenkins.model.*
 /* Global variables are decalred without `def` as they must be used in both
  * declaritive and scripted mode */
 collectBuilders = [:]
-boardTestQueue = []
-totalResults = [:]
+boardTestQueue = [].asSynchronized()
+totalResults = [:].asSynchronized()
 nodeBoards = []
 
 /* pipeline ================================================================= */


### PR DESCRIPTION
The PR does the following:
- Protect the boardTestQueue from concurrency issues due to popping items in a parallel processes by using the `as Synchronized()` modifier
- Protect the totalResults from corruption with `as Synchronized()` modifier
- archive failed console logs (with some nice html wrapper) when building or testing
- Provide links to failed console logs in comment on PR table